### PR TITLE
Reactivate qwtPlotCurve.py test

### DIFF
--- a/libscidavis/src/scidavis.sip
+++ b/libscidavis/src/scidavis.sip
@@ -767,6 +767,9 @@ class QwtPlotCurve
 
 		void setSymbol(const QwtSymbol &s);
 		const QwtSymbol& symbol() const;
+%MethodCode
+	sipRes = sipCpp->symbol().clone();
+%End
 
 	 // convenience methods for scripting
 	 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,10 +72,6 @@ if( SCRIPTING_PYTHON )
   file( COPY ../scidavis-logo.png DESTINATION ./tmp )
 
   file( GLOB pythonTests pythonTests/*.py )
-  # qwtPlotCurve segfault with sip5 or macos
-  if( SIP_VERSION VERSION_GREATER_EQUAL 5 OR APPLE OR MSYS )
-    list( REMOVE_ITEM pythonTests ${CMAKE_CURRENT_SOURCE_DIR}/pythonTests/qwtPlotCurve.py )
-  endif()
 
   foreach( pythonTest ${pythonTests} )
     get_filename_component( test_name ${pythonTest} NAME_WLE )


### PR DESCRIPTION
Verified with openSUSE (Tumbleweed 20210602) with Qt 5.15.2, Python 3.8.10, sip 5.5.0.
Verified with Ubuntu 21.04 with Qt 5.15.2, Python 3.9.5, sip 5.5.0.