### PR TITLE
Add Education and Math categories to scidavis.desktop

### DIFF
--- a/scidavis/scidavis.desktop
+++ b/scidavis/scidavis.desktop
@@ -49,5 +49,5 @@ Icon=scidavis
 Exec=scidavis
 Terminal=false
 MimeType=application/x-sciprj;
-Categories=Qt;Science;DataVisualization;
+Categories=Qt;Science;DataVisualization;Math;Education;
 X-KDE-SubstituteUID=false


### PR DESCRIPTION
Otherwise it showed up in "Other" category in XFCE (and most likely also in MATE), where there is no "Science" category by default, but there is one "Education" category.
**Before**
![before](https://user-images.githubusercontent.com/3063132/121768725-4857db80-cb7d-11eb-8511-6359c63d6591.png)
It only showed up in "Other" category.

**After**
![after](https://user-images.githubusercontent.com/3063132/121768738-5dcd0580-cb7d-11eb-924d-bbbf30fe2af0.png)
And it does not anymore show up in the "Other" category.
