### PR TITLE
Fix bug sf #424: Unable to reopen project files with minimized Graph …

### DIFF
--- a/libscidavis/src/ApplicationWindow.cpp
+++ b/libscidavis/src/ApplicationWindow.cpp
@@ -3752,6 +3752,7 @@ bool ApplicationWindow::loadProject(const QString &fn)
             QStringList graph = s.split("\t");
             QString caption = graph[0];
             plot = multilayerPlot(caption);
+            plot->mdiArea()->setActiveSubWindow(plot);
             plot->setCols(graph[1].toInt());
             plot->setRows(graph[2].toInt());
 

--- a/libscidavis/src/Graph.cpp
+++ b/libscidavis/src/Graph.cpp
@@ -54,6 +54,7 @@
 #include "PlotCurve.h"
 #include "ApplicationWindow.h"
 #include "core/column/Column.h"
+#include "MultiLayer.h"
 
 #include <QApplication>
 #include <QBitmap>
@@ -3848,9 +3849,12 @@ bool Graph::addFunctionCurve(ApplicationWindow *parent, int type, const QStringL
     c_keys[n_curves - 1] = d_plot->insertCurve(c);
 
     addLegendItem(c->legend());
-    updatePlot();
+    auto ml = qobject_cast<MultiLayer *>(parent->d_workspace.activeSubWindow());
+    if (ml &&  ml->status() != MyWidget::Minimized) {
+        updatePlot();
 
-    emit modifiedGraph();
+        emit modifiedGraph();
+    }
     return true;
 }
 

--- a/libscidavis/src/Matrix.cpp
+++ b/libscidavis/src/Matrix.cpp
@@ -87,6 +87,7 @@ void Matrix::init(int, int)
 
     birthdate = QLocale().toString(d_future_matrix->creationTime());
 
+    setMinimumSize(400, 300);
     // this is not very nice but works for the moment
     ui.gridLayout2->removeWidget(ui.formula_box);
     delete ui.formula_box;

--- a/libscidavis/src/MultiLayer.cpp
+++ b/libscidavis/src/MultiLayer.cpp
@@ -140,7 +140,7 @@ MultiLayer::MultiLayer(const QString &label, QWidget *parent, const QString name
     pal.setColor(QPalette::Window, QColor(Qt::white));
     d_main_widget->setPalette(pal);
 
-    setMinimumSize(200, 150);
+    setMinimumSize(400, 300);
     setGeometry(QRect(0, 0, graph_width, graph_height));
     setFocusPolicy(Qt::StrongFocus);
 }

--- a/libscidavis/src/Table.cpp
+++ b/libscidavis/src/Table.cpp
@@ -102,6 +102,7 @@ void Table::init()
     } else // the rest is meaningless
         return;
 
+    setMinimumSize(400, 300);
     ui.gridLayout1->removeWidget(ui.formula_box);
     delete ui.formula_box;
     ui.formula_box = new ScriptEdit(scriptEnv, ui.formula_tab);


### PR DESCRIPTION
Fix bug sf [#424](https://sourceforge.net/p/scidavis/scidavis-bugs/424/): Unable to reopen project files with minimized Graph windows that have FunctionCurve curves

When loading a project, adding a FunctionCurve to a Graph Widget triggers Graph::updatePlot() with the consequent plot's layout recalculation.
A minimized MultiLayer MdiSubwindow has a too small geometry/size for the recalculation to succeed.
Thus, delay updatePlot() until window is un-minimized.
