### PR TITLE
libscidavis/CMakeLists.txt: fix build if sip-4 installed.

### DIFF
--- a/libscidavis/CMakeLists.txt
+++ b/libscidavis/CMakeLists.txt
@@ -483,7 +483,7 @@ if( SCRIPTING_PYTHON )
   set(scidavis_PyQt_HDR ${scidavis_SIP_OUTPUT_DIR}/sipAPIscidavis.h)
   if( SIP_VERSION VERSION_GREATER_EQUAL 5 )
     set( scidavis_SIP_HDR ${CMAKE_CURRENT_BINARY_DIR}/python/sip.h )
-    target_include_directories( libscidavis PUBLIC
+    target_include_directories( libscidavis BEFORE PUBLIC
       "${CMAKE_CURRENT_BINARY_DIR}/python"
       "${scidavis_SIP_OUTPUT_DIR}"
     )


### PR DESCRIPTION
This small patch fixes a bug where compilation would fail if both sip-4 and sip-6 are installed.

Sip-4 installs `/usr/include/pythonX.Y/sip.h` which would override the `sip.h` generated by sip-6, resulting in this bug: https://bugs.gentoo.org/828938

Solution is to explicitly put the generated `sip.h` before the system `sip.h`.

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>