### PR TITLE
was like "step size", became like "number of steps"

### DIFF
--- a/scidavis/translations/scidavis_ru.ts
+++ b/scidavis/translations/scidavis_ru.ts
@@ -4146,13 +4146,13 @@ Are you sure you want to continue?</source>
         <location filename="../../libscidavis/src/AxesDialog.cpp" line="153" />
         <location filename="../../libscidavis/src/AxesDialog.cpp" line="452" />
         <source>Major Ticks</source>
-        <translation>Шаг основной разметки</translation>
+        <translation>Шагов основной разметки</translation>
     </message>
     <message>
         <location filename="../../libscidavis/src/AxesDialog.cpp" line="160" />
         <location filename="../../libscidavis/src/AxesDialog.cpp" line="461" />
         <source>Minor Ticks</source>
-        <translation>Шаг дополнительной разметки</translation>
+        <translation>Шагов дополнительной разметки</translation>
     </message>
     <message>
         <location filename="../../libscidavis/src/AxesDialog.cpp" line="181" />


### PR DESCRIPTION
Small fix of translation. Was like "step size", became like "number of steps" (in section "Major Ticks" and "Minor Ticks")